### PR TITLE
Allow to use Doctrine listeners with both ORM and ODM

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,10 @@ You can use your own salt generator. You just have to declare a service implemen
 ##Change the initial password generator
 
 You can change the default password generator. By default, the rad-users uses the [hackzilla/password-generator](https://github.com/hackzilla/password-generator). You can chenga it by implementing the `Knp\Rad\User\Password\Generator` interface and tag the service with the `knp_rad_user.password_generator` tag.
+
+##Using with MongoDB or CouchDB Object Document Mapper
+
+```yaml
+knp_rad_user:
+    doctrine_driver: mongodb # available values: orm (by default), mongodb or couchdb
+```

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "doctrine/orm": "~2.0",
+        "doctrine/common": "~2.0",
         "symfony/dependency-injection": "~2.0",
         "symfony/http-kernel": "~2.0",
         "symfony/security-core": "~2.0",

--- a/spec/Knp/Rad/User/EventListener/PasswordGenerationListenerSpec.php
+++ b/spec/Knp/Rad/User/EventListener/PasswordGenerationListenerSpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\Knp\Rad\User\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Knp\Rad\User\Password\Generator;
 use Knp\Rad\User\HasInitialPassword;
 use PhpSpec\ObjectBehavior;

--- a/spec/Knp/Rad/User/EventListener/PasswordHashListenerSpec.php
+++ b/spec/Knp/Rad/User/EventListener/PasswordHashListenerSpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\Knp\Rad\User\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Knp\Rad\User\HasPassword;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;

--- a/spec/Knp/Rad/User/EventListener/SaltGenerationListenerSpec.php
+++ b/spec/Knp/Rad/User/EventListener/SaltGenerationListenerSpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\Knp\Rad\User\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Knp\Rad\User\Salt\Generator;
 use Knp\Rad\User\HasSalt;
 use PhpSpec\ObjectBehavior;

--- a/src/Knp/Rad/User/DependencyInjection/Configuration.php
+++ b/src/Knp/Rad/User/DependencyInjection/Configuration.php
@@ -17,13 +17,9 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('doctrine_driver')
-                    ->validate()
-                        ->ifNotInArray(['orm', 'mongodb', 'couchdb'])
-                        ->thenInvalid('Invalid Doctrine driver %s.')
-                    ->end()
+                ->enumNode('doctrine_driver')
+                    ->values(['orm', 'mongodb', 'couchdb'])
                     ->defaultValue('orm')
-                    ->cannotBeEmpty()
                 ->end();
 
         return $treeBuilder;

--- a/src/Knp/Rad/User/DependencyInjection/Configuration.php
+++ b/src/Knp/Rad/User/DependencyInjection/Configuration.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Knp\Rad\User\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('knp_rad_user');
+
+        $rootNode
+            ->children()
+                ->scalarNode('doctrine_driver')
+                    ->validate()
+                        ->ifNotInArray(['orm', 'mongodb', 'couchdb'])
+                        ->thenInvalid('Invalid Doctrine driver %s.')
+                    ->end()
+                    ->defaultValue('orm')
+                    ->cannotBeEmpty()
+                ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/Knp/Rad/User/DependencyInjection/UserExtension.php
+++ b/src/Knp/Rad/User/DependencyInjection/UserExtension.php
@@ -13,10 +13,59 @@ class UserExtension extends Extension
     /**
      * {@inheritDoc}
      */
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container)
     {
+        $configuration = new Configuration();
+
+        $config = $this->processConfiguration($configuration, $configs);
+
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        $tagName = null;
+        switch ($config['doctrine_driver']) {
+            case 'orm':
+                $tagName = 'doctrine.event_listener';
+                break;
+            case 'mongodb':
+                $tagName = 'doctrine_mongodb.odm.event_listener';
+                break;
+            case 'couchdb':
+                $tagName = 'doctrine_couchdb.event_listener';
+                break;
+        }
+
+        if (null === $tagName) {
+            return;
+        }
+
+        $container
+            ->getDefinition('knp_rad_user.event_listener.password_generation_listener')
+            ->addTag($tagName, [
+                'event'    => 'prePersist',
+                'method'   => 'prePersist',
+                'priority' => 200,
+            ]);
+
+        $container
+            ->getDefinition('knp_rad_user.event_listener.password_hash_listener')
+            ->addTag($tagName, [
+                'event'    => 'prePersist',
+                'method'   => 'prePersist',
+                'priority' => 100,
+            ])
+            ->addTag($tagName, [
+                'event'    => 'preUpdate',
+                'method'   => 'preUpdate',
+            ]);
+
+        $container
+            ->getDefinition('knp_rad_user.event_listener.salt_generation_listener')
+            ->addTag($tagName, [
+                'event'    => 'prePersist',
+                'method'   => 'prePersist',
+                'priority' => 200,
+            ]);
     }
 
     /**

--- a/src/Knp/Rad/User/EventListener/PasswordGenerationListener.php
+++ b/src/Knp/Rad/User/EventListener/PasswordGenerationListener.php
@@ -2,7 +2,7 @@
 
 namespace Knp\Rad\User\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Knp\Rad\User\Password\Generator;
 use Knp\Rad\User\Password\Generator\HackzillaGenerator;
 use Knp\Rad\User\HasInitialPassword;

--- a/src/Knp/Rad/User/EventListener/PasswordHashListener.php
+++ b/src/Knp/Rad/User/EventListener/PasswordHashListener.php
@@ -2,7 +2,7 @@
 
 namespace Knp\Rad\User\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Knp\Rad\User\HasPassword;
 use Knp\Rad\User\HasSalt;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;

--- a/src/Knp/Rad/User/EventListener/SaltGenerationListener.php
+++ b/src/Knp/Rad/User/EventListener/SaltGenerationListener.php
@@ -2,7 +2,7 @@
 
 namespace Knp\Rad\User\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Knp\Rad\User\Salt\Generator;
 use Knp\Rad\User\Salt\Generator\DefaultGenerator;
 use Knp\Rad\User\HasSalt;

--- a/src/Knp/Rad/User/Resources/config/services.yml
+++ b/src/Knp/Rad/User/Resources/config/services.yml
@@ -2,21 +2,13 @@ services:
     knp_rad_user.event_listener.password_generation_listener:
         class: Knp\Rad\User\EventListener\PasswordGenerationListener
         public: false
-        tags:
-            - { name: doctrine.event_listener, event: prePersist, method: prePersist, priority: 200 }
 
     knp_rad_user.event_listener.password_hash_listener:
         class: Knp\Rad\User\EventListener\PasswordHashListener
         public: false
         arguments:
             - @security.encoder_factory
-        tags:
-            - { name: doctrine.event_listener, event: preUpdate, method: preUpdate }
-            - { name: doctrine.event_listener, event: prePersist, method: prePersist, priority: 100 }
 
     knp_rad_user.event_listener.salt_generation_listener:
         class: Knp\Rad\User\EventListener\SaltGenerationListener
         public: false
-        tags:
-            - { name: doctrine.event_listener, event: prePersist, method: prePersist, priority: 200 }
-


### PR DESCRIPTION
Added a configuration to tag listeners to Doctrine ORM or ODM:

```yaml
knp_rad_user:
    doctrine_driver: mongodb # available values: orm (by default), mongodb or couchdb
```