### PR TITLE
Fixes #27 Cannot use { or } in salt. [incomplete]

### DIFF
--- a/src/Knp/Rad/User/Salt/Generator/PseudoRandomBytesGenerator.php
+++ b/src/Knp/Rad/User/Salt/Generator/PseudoRandomBytesGenerator.php
@@ -24,6 +24,6 @@ class PseudoRandomBytesGenerator implements Generator
      */
     public function generate()
     {
-        return openssl_random_pseudo_bytes($this->length);
+        return bin2hex(openssl_random_pseudo_bytes($this->length));
     }
 }


### PR DESCRIPTION
`hex2bin` make the string twice as long (255 -> 510)

We could use `($this->length / 2)` but it can never generate an odd number of chars (like, say, 255)
Or `strlen()` to trim it.
Or a combination of these two, to have exactly the number of chars specified in the configuration.